### PR TITLE
Fixed app state when no results in ngRepeat

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -26,9 +26,9 @@ angular.module('App', [])
       else {
         appTweets(q, function(data) {
           cache = $scope.tweets = data;
-          appLoading.ready();
         });
       }
+      appLoading.ready();
     };
     $scope.search('angularjs');
   })


### PR DESCRIPTION
In the AppRepeatCtrl controller, the search function when receives 
the argument q with value false, it is not calling the appLoading.ready() 
before exiting function, which means the app stays in the 'loading' state.
This minor change fixes this behavior.
